### PR TITLE
Audit-driven test improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /coverage/
 /node_modules/
 /vendor/
+.phpunit.result.cache

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,9 +49,8 @@ CI matrix: PHP 7.4 + 8.4 against WP latest, both single-site and multisite, on e
 **Asset variants.** Both `js/` and `css/` ship a production file (`wpss-search-suggest.js` / `.css`) and a `.dev.*` counterpart. `wpss_init` picks the `.dev` variant when `SCRIPT_DEBUG` is true. Asset versions are read from the plugin header via `get_file_data( __FILE__, ... 'Version' ... )` — bumping the `Version:` header in `wp-search-suggest.php` is what busts cached assets.
 
 **Tests.** Two suites under `tests/`:
-- `test-ajax-requests.php` (extends `WP_Ajax_UnitTestCase`) exercises the `wp-search-suggest` AJAX endpoint with valid/invalid nonces and logged-in/out roles.
-- `test-wp-search-suggest.php` (extends `WP_UnitTestCase`) covers the registration helpers (`wpss_init` script + style + `wpss_options` localisation, `wpss_enqueue_scripts`) and the title→post-ID lookup (`wpss_get_post_id_from_title`, including the `post_status = 'publish'` filter and the object-cache key).
-- The `wpss_post_url` AJAX wrapper itself isn't directly tested, but its core lookup is covered by the helper tests.
+- `test-ajax-requests.php` (extends `WP_Ajax_UnitTestCase`) exercises both AJAX endpoints — `wp-search-suggest` (valid/invalid nonces and logged-in/out roles) and `wpss-post-url` (matching title, no-match, invalid nonce on the `wpss-post-url` action).
+- `test-wp-search-suggest.php` (extends `WP_UnitTestCase`) covers the registration helpers (`wpss_init` script + style + `wpss_options` localisation including the two distinct nonces and SCRIPT_DEBUG-driven asset suffix, `wpss_enqueue_scripts`) and the title→post-ID lookup (`wpss_get_post_id_from_title`, including the `post_status = 'publish'` filter and the object-cache hit path).
 
 `tests/bootstrap.php` is wp-env-aware: it loads the plugin on `muplugins_loaded` against the WP test suite that wp-env mounts inside the `tests-cli` container.
 

--- a/tests/test-ajax-requests.php
+++ b/tests/test-ajax-requests.php
@@ -66,8 +66,8 @@ class Ajax_Requests extends WP_Ajax_UnitTestCase {
 			)
 		);
 
-		$_GET['title']    = 'Sample Post Title';
-		$_GET['_wpnonce'] = wp_create_nonce( 'wpss-post-url' );
+		$_POST['title']    = 'Sample Post Title';
+		$_POST['_wpnonce'] = wp_create_nonce( 'wpss-post-url' );
 
 		try {
 			$this->_handleAjax( 'wpss-post-url' );
@@ -86,8 +86,8 @@ class Ajax_Requests extends WP_Ajax_UnitTestCase {
 	 * @covers ::wpss_post_url
 	 */
 	public function test_post_url_returns_empty_response_when_no_post_matches() {
-		$_GET['title']    = 'No Such Title Exists';
-		$_GET['_wpnonce'] = wp_create_nonce( 'wpss-post-url' );
+		$_POST['title']    = 'No Such Title Exists';
+		$_POST['_wpnonce'] = wp_create_nonce( 'wpss-post-url' );
 
 		try {
 			$this->_handleAjax( 'wpss-post-url' );
@@ -113,8 +113,8 @@ class Ajax_Requests extends WP_Ajax_UnitTestCase {
 	 * @covers ::wpss_post_url
 	 */
 	public function test_post_url_rejects_invalid_nonce() {
-		$_GET['title']    = 'Sample Post Title';
-		$_GET['_wpnonce'] = 'invalid_nonce';
+		$_POST['title']    = 'Sample Post Title';
+		$_POST['_wpnonce'] = 'invalid_nonce';
 
 		try {
 			$this->_handleAjax( 'wpss-post-url' );

--- a/tests/test-ajax-requests.php
+++ b/tests/test-ajax-requests.php
@@ -11,14 +11,6 @@
 class Ajax_Requests extends WP_Ajax_UnitTestCase {
 
 	/**
-	 * Resets request superglobals between tests so state cannot leak across cases.
-	 */
-	public function tear_down() {
-		unset( $_GET['q'], $_GET['_wpnonce'], $_REQUEST['title'], $_REQUEST['_wpnonce'] );
-		parent::tear_down();
-	}
-
-	/**
 	 * Suggest endpoint returns the matching post title for a logged-in user.
 	 *
 	 * @covers ::wpss_ajax_response
@@ -74,8 +66,8 @@ class Ajax_Requests extends WP_Ajax_UnitTestCase {
 			)
 		);
 
-		$_REQUEST['title']    = 'Sample Post Title';
-		$_REQUEST['_wpnonce'] = wp_create_nonce( 'wpss-post-url' );
+		$_GET['title']    = 'Sample Post Title';
+		$_GET['_wpnonce'] = wp_create_nonce( 'wpss-post-url' );
 
 		try {
 			$this->_handleAjax( 'wpss-post-url' );
@@ -94,8 +86,8 @@ class Ajax_Requests extends WP_Ajax_UnitTestCase {
 	 * @covers ::wpss_post_url
 	 */
 	public function test_post_url_returns_empty_response_when_no_post_matches() {
-		$_REQUEST['title']    = 'No Such Title Exists';
-		$_REQUEST['_wpnonce'] = wp_create_nonce( 'wpss-post-url' );
+		$_GET['title']    = 'No Such Title Exists';
+		$_GET['_wpnonce'] = wp_create_nonce( 'wpss-post-url' );
 
 		try {
 			$this->_handleAjax( 'wpss-post-url' );
@@ -117,8 +109,8 @@ class Ajax_Requests extends WP_Ajax_UnitTestCase {
 	 * @covers ::wpss_post_url
 	 */
 	public function test_post_url_rejects_invalid_nonce() {
-		$_REQUEST['title']    = 'Sample Post Title';
-		$_REQUEST['_wpnonce'] = 'invalid_nonce';
+		$_GET['title']    = 'Sample Post Title';
+		$_GET['_wpnonce'] = 'invalid_nonce';
 
 		try {
 			$this->_handleAjax( 'wpss-post-url' );

--- a/tests/test-ajax-requests.php
+++ b/tests/test-ajax-requests.php
@@ -91,8 +91,12 @@ class Ajax_Requests extends WP_Ajax_UnitTestCase {
 
 		try {
 			$this->_handleAjax( 'wpss-post-url' );
-		} catch ( WPAjaxDieContinueException $exception ) {
-			// Expected: wp_die() at end of handler.
+		} catch ( WPAjaxDieStopException $exception ) {
+			/*
+			 * Expected: wp_die() at end of handler. WP_Ajax_UnitTestCase throws
+			 * the Stop variant when nothing was echoed (here, because the title
+			 * matches no post and the esc_url(...) branch is skipped).
+			 */
 		}
 
 		$this->assertSame( '', $this->_last_response );

--- a/tests/test-ajax-requests.php
+++ b/tests/test-ajax-requests.php
@@ -1,106 +1,167 @@
 <?php // phpcs:disable Generic.CodeAnalysis.EmptyStatement.DetectedCatch
 /**
- * Ajax requests test file.
+ * Tests for the two AJAX endpoints exposed by the plugin.
  *
  * @package wp-search-suggest
  */
 
 /**
- * User meta related tests.
+ * Covers wp_ajax(_nopriv)_wp-search-suggest and wp_ajax(_nopriv)_wpss-post-url.
  */
 class Ajax_Requests extends WP_Ajax_UnitTestCase {
 
 	/**
-	 * Set up before class.
+	 * Resets request superglobals between tests so state cannot leak across cases.
 	 */
-	public static function set_up_before_class() {
-		parent::set_up_before_class();
-
-		add_action( 'wp_ajax_wp-search-suggest', 'wpss_ajax_response' );
-		add_action( 'wp_ajax_nopriv_wp-search-suggest', 'wpss_ajax_response' );
+	public function tear_down() {
+		unset( $_GET['q'], $_GET['_wpnonce'], $_REQUEST['title'], $_REQUEST['_wpnonce'] );
+		parent::tear_down();
 	}
 
 	/**
-	 * Tests whether a logged-in user can access the AJAX request.
+	 * Suggest endpoint returns the matching post title for a logged-in user.
 	 *
 	 * @covers ::wpss_ajax_response
 	 */
-	public function test_logged_in_user_can_access() {
-		// Simulate a logged-in user.
+	public function test_suggest_returns_matching_post_title_for_logged_in_user() {
 		$this->_setRole( 'subscriber' );
-
-		// Create a test post with a specific title.
-		$post_id = $this->factory->post->create( array( 'post_title' => 'Sample Post Title' ) );
-
-		// Set up the request with the first word of the post title as the query.
-		$_GET['q']        = 'Sample';
-		$_GET['_wpnonce'] = wp_create_nonce( 'wp-search-suggest' );
-
-		// Make the request.
-		try {
-			$this->_handleAjax( 'wp-search-suggest' );
-		} catch ( WPAjaxDieContinueException $exception ) {
-			// We expect this exception to be thrown.
-		}
-
-		// Assert that the response contains the post title.
-		$this->assertSame( 'Sample Post Title', $this->_last_response );
-
-		// Clean up by deleting the test post.
-		wp_delete_post( $post_id, true );
+		$this->assert_suggest_returns_title();
 	}
 
 	/**
-	 * Tests whether a logged-out user can access the AJAX request.
+	 * Suggest endpoint returns the matching post title for a logged-out user.
 	 *
 	 * @covers ::wpss_ajax_response
 	 */
-	public function test_logged_out_user_can_access() {
-		// Simulate a logged-out user.
+	public function test_suggest_returns_matching_post_title_for_logged_out_user() {
 		$this->logout();
+		$this->assert_suggest_returns_title();
+	}
 
-		// Create a test post with a specific title.
-		$post_id = $this->factory->post->create( array( 'post_title' => 'Sample Post Title' ) );
+	/**
+	 * Suggest endpoint rejects an invalid nonce when logged in.
+	 *
+	 * @covers ::wpss_ajax_response
+	 */
+	public function test_suggest_rejects_invalid_nonce_when_logged_in() {
+		$this->_setRole( 'subscriber' );
+		$this->assert_suggest_rejects_invalid_nonce();
+	}
 
-		// Set up the request with the first word of the post title as the query.
-		$_GET['q']        = 'Sample';
-		$_GET['_wpnonce'] = wp_create_nonce( 'wp-search-suggest' );
+	/**
+	 * Suggest endpoint rejects an invalid nonce when logged out.
+	 *
+	 * The wp_ajax_nopriv_* hook runs the same nonce check; this guards against the
+	 * nopriv branch silently accepting unauthenticated requests.
+	 *
+	 * @covers ::wpss_ajax_response
+	 */
+	public function test_suggest_rejects_invalid_nonce_when_logged_out() {
+		$this->logout();
+		$this->assert_suggest_rejects_invalid_nonce();
+	}
 
-		// Make the request.
+	/**
+	 * Post URL endpoint returns the permalink for a published post matching the title.
+	 *
+	 * @covers ::wpss_post_url
+	 */
+	public function test_post_url_returns_permalink_for_matching_title() {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_title'  => 'Sample Post Title',
+				'post_status' => 'publish',
+			)
+		);
+
+		$_REQUEST['title']    = 'Sample Post Title';
+		$_REQUEST['_wpnonce'] = wp_create_nonce( 'wpss-post-url' );
+
 		try {
-			$this->_handleAjax( 'wp-search-suggest' );
+			$this->_handleAjax( 'wpss-post-url' );
 		} catch ( WPAjaxDieContinueException $exception ) {
-			// We expect this exception to be thrown.
+			// Expected: wp_die() at end of handler.
 		}
 
-		// Assert that the response contains the post title.
-		$this->assertSame( 'Sample Post Title', $this->_last_response );
+		$this->assertSame( get_permalink( $post_id ), $this->_last_response );
 
-		// Clean up by deleting the test post.
 		wp_delete_post( $post_id, true );
 	}
 
 	/**
-	 * Tests whether an invalid nonce is rejected.
+	 * Post URL endpoint returns an empty response when no post matches the title.
 	 *
-	 * @covers ::wpss_ajax_response
+	 * @covers ::wpss_post_url
 	 */
-	public function test_invalid_nonce_for_logged_in_user() {
-		// Simulate a logged-in user.
-		$this->_setRole( 'subscriber' );
+	public function test_post_url_returns_empty_response_when_no_post_matches() {
+		$_REQUEST['title']    = 'No Such Title Exists';
+		$_REQUEST['_wpnonce'] = wp_create_nonce( 'wpss-post-url' );
 
-		// Set up the request with the invalid nonce.
+		try {
+			$this->_handleAjax( 'wpss-post-url' );
+		} catch ( WPAjaxDieContinueException $exception ) {
+			// Expected: wp_die() at end of handler.
+		}
+
+		$this->assertSame( '', $this->_last_response );
+	}
+
+	/**
+	 * Post URL endpoint rejects an invalid nonce.
+	 *
+	 * The plugin uses TWO distinct nonces (`wp-search-suggest` for suggest,
+	 * `wpss-post-url` for the URL resolver). This test guards the second one
+	 * — collapsing the two would make this assertion still pass under suggest
+	 * but break the URL endpoint in production.
+	 *
+	 * @covers ::wpss_post_url
+	 */
+	public function test_post_url_rejects_invalid_nonce() {
+		$_REQUEST['title']    = 'Sample Post Title';
+		$_REQUEST['_wpnonce'] = 'invalid_nonce';
+
+		try {
+			$this->_handleAjax( 'wpss-post-url' );
+		} catch ( WPAjaxDieStopException $exception ) {
+			// Expected: check_ajax_referer() dies with -1 on failure.
+		}
+
+		$this->assertEmpty( $this->_last_response );
+	}
+
+	/**
+	 * Asserts the suggest endpoint returns the matching post title for the current request state.
+	 */
+	private function assert_suggest_returns_title() {
+		$post_id = self::factory()->post->create( array( 'post_title' => 'Sample Post Title' ) );
+
+		$_GET['q']        = 'Sample';
+		$_GET['_wpnonce'] = wp_create_nonce( 'wp-search-suggest' );
+
+		try {
+			$this->_handleAjax( 'wp-search-suggest' );
+		} catch ( WPAjaxDieContinueException $exception ) {
+			// Expected: wp_die() at end of handler.
+		}
+
+		$this->assertSame( 'Sample Post Title', $this->_last_response );
+
+		wp_delete_post( $post_id, true );
+	}
+
+	/**
+	 * Asserts the suggest endpoint rejects an invalid nonce for the current request state.
+	 */
+	private function assert_suggest_rejects_invalid_nonce() {
 		$_GET['q']        = 'Title';
 		$_GET['_wpnonce'] = 'invalid_nonce';
 
-		// Make the request.
 		try {
 			$this->_handleAjax( 'wp-search-suggest' );
 		} catch ( WPAjaxDieStopException $exception ) {
-			// We expect this exception to be thrown.
+			// Expected: check_ajax_referer() dies with -1 on failure.
 		}
 
-		// Assert that the response contains an error message.
 		$this->assertEmpty( $this->_last_response );
 	}
 }

--- a/tests/test-wp-search-suggest.php
+++ b/tests/test-wp-search-suggest.php
@@ -187,9 +187,16 @@ class Test_WP_Search_Suggest extends WP_UnitTestCase {
 	/**
 	 * Decodes the JSON object that `wp_localize_script` emits for `wpss_options`.
 	 *
-	 * Reads the `data` extra (`var wpss_options = {...};`), extracts the JSON
-	 * object literal, and returns the decoded array — robust against future
-	 * WordPress changes to whitespace or property ordering inside the assignment.
+	 * Reads the `data` extra (`var wpss_options = {...};`), extracts the first
+	 * JSON object literal, and returns the decoded array — robust against
+	 * future WordPress changes to whitespace or property ordering inside the
+	 * assignment.
+	 *
+	 * Note: `wp_localize_script` *appends* to the data extra, so when the
+	 * `init` hook has already fired before a test calls `wpss_init()`, the
+	 * data string contains two `var wpss_options = {...};` statements with
+	 * identical payloads. The regex below is intentionally non-greedy so it
+	 * captures only the first object instead of spanning across both.
 	 *
 	 * @return array Decoded wpss_options payload.
 	 */
@@ -199,7 +206,7 @@ class Test_WP_Search_Suggest extends WP_UnitTestCase {
 		$this->assertNotEmpty( $data, 'Expected wpss_options to be localised onto the script.' );
 		$this->assertSame(
 			1,
-			preg_match( '/wpss_options\s*=\s*(\{.*\});/s', $data, $matches ),
+			preg_match( '/wpss_options\s*=\s*(\{.*?\});/s', $data, $matches ),
 			'Could not locate the wpss_options assignment in localised data.'
 		);
 

--- a/tests/test-wp-search-suggest.php
+++ b/tests/test-wp-search-suggest.php
@@ -57,20 +57,17 @@ class Test_WP_Search_Suggest extends WP_UnitTestCase {
 	public function test_init_localises_two_distinct_nonces() {
 		wpss_init();
 
-		global $wp_scripts;
-		$data = (string) $wp_scripts->get_data( 'wp-search-suggest', 'data' );
+		$options = $this->get_localised_wpss_options();
 
-		$post_url_nonce = '';
-		if ( preg_match( '/"nonce":"([^"]+)"/', $data, $matches ) ) {
-			$post_url_nonce = $matches[1];
-		}
+		$this->assertArrayHasKey( 'nonce', $options, 'Expected a wpss-post-url nonce on wpss_options.nonce.' );
+		$this->assertArrayHasKey( 'ajaxurl', $options, 'Expected wpss_options.ajaxurl to be localised.' );
 
-		$suggest_nonce = '';
-		if ( preg_match( '/_wpnonce=([a-zA-Z0-9]+)/', $data, $matches ) ) {
-			$suggest_nonce = $matches[1];
-		}
+		$ajax_args = array();
+		wp_parse_str( (string) wp_parse_url( $options['ajaxurl'], PHP_URL_QUERY ), $ajax_args );
 
-		$this->assertNotEmpty( $post_url_nonce, 'Expected a wpss-post-url nonce on wpss_options.nonce.' );
+		$post_url_nonce = $options['nonce'];
+		$suggest_nonce  = isset( $ajax_args['_wpnonce'] ) ? $ajax_args['_wpnonce'] : '';
+
 		$this->assertNotEmpty( $suggest_nonce, 'Expected a wp-search-suggest nonce inside wpss_options.ajaxurl.' );
 		$this->assertNotSame( $post_url_nonce, $suggest_nonce, 'The two endpoints must use distinct nonces.' );
 		$this->assertNotFalse( wp_verify_nonce( $post_url_nonce, 'wpss-post-url' ), 'wpss_options.nonce must verify against wpss-post-url.' );
@@ -185,5 +182,30 @@ class Test_WP_Search_Suggest extends WP_UnitTestCase {
 			(string) wp_cache_get( 'wpss_post_title' . $title, 'post' ),
 			'Expected the post ID to be cached under wpss_post_title<title>.'
 		);
+	}
+
+	/**
+	 * Decodes the JSON object that `wp_localize_script` emits for `wpss_options`.
+	 *
+	 * Reads the `data` extra (`var wpss_options = {...};`), extracts the JSON
+	 * object literal, and returns the decoded array — robust against future
+	 * WordPress changes to whitespace or property ordering inside the assignment.
+	 *
+	 * @return array Decoded wpss_options payload.
+	 */
+	private function get_localised_wpss_options() {
+		$data = (string) wp_scripts()->get_data( 'wp-search-suggest', 'data' );
+
+		$this->assertNotEmpty( $data, 'Expected wpss_options to be localised onto the script.' );
+		$this->assertSame(
+			1,
+			preg_match( '/wpss_options\s*=\s*(\{.*\});/s', $data, $matches ),
+			'Could not locate the wpss_options assignment in localised data.'
+		);
+
+		$decoded = json_decode( $matches[1], true );
+		$this->assertIsArray( $decoded, 'wpss_options payload was not valid JSON.' );
+
+		return $decoded;
 	}
 }

--- a/tests/test-wp-search-suggest.php
+++ b/tests/test-wp-search-suggest.php
@@ -47,6 +47,73 @@ class Test_WP_Search_Suggest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * `wpss_init` localises two distinct nonces — one per AJAX endpoint.
+	 *
+	 * The plugin uses `wpss-post-url` for the URL resolver and `wp-search-suggest`
+	 * for the suggest endpoint. Conflating the two would leave one endpoint
+	 * accepting nonces minted for the other; this test fails if a future change
+	 * collapses them.
+	 */
+	public function test_init_localises_two_distinct_nonces() {
+		wpss_init();
+
+		global $wp_scripts;
+		$data = (string) $wp_scripts->get_data( 'wp-search-suggest', 'data' );
+
+		$post_url_nonce = '';
+		if ( preg_match( '/"nonce":"([^"]+)"/', $data, $matches ) ) {
+			$post_url_nonce = $matches[1];
+		}
+
+		$suggest_nonce = '';
+		if ( preg_match( '/_wpnonce=([a-zA-Z0-9]+)/', $data, $matches ) ) {
+			$suggest_nonce = $matches[1];
+		}
+
+		$this->assertNotEmpty( $post_url_nonce, 'Expected a wpss-post-url nonce on wpss_options.nonce.' );
+		$this->assertNotEmpty( $suggest_nonce, 'Expected a wp-search-suggest nonce inside wpss_options.ajaxurl.' );
+		$this->assertNotSame( $post_url_nonce, $suggest_nonce, 'The two endpoints must use distinct nonces.' );
+		$this->assertNotFalse( wp_verify_nonce( $post_url_nonce, 'wpss-post-url' ), 'wpss_options.nonce must verify against wpss-post-url.' );
+		$this->assertNotFalse( wp_verify_nonce( $suggest_nonce, 'wp-search-suggest' ), 'wpss_options.ajaxurl nonce must verify against wp-search-suggest.' );
+	}
+
+	/**
+	 * `wpss_init` registers both assets with the version from the plugin header.
+	 *
+	 * Pinning this contract guarantees that a release that bumps the `Version:`
+	 * header actually busts cached asset URLs.
+	 */
+	public function test_init_uses_plugin_header_version_for_assets() {
+		wpss_init();
+
+		$plugin_data = get_file_data(
+			dirname( __DIR__ ) . '/wp-search-suggest.php',
+			array( 'Version' => 'Version' ),
+			'plugin'
+		);
+
+		$this->assertSame( $plugin_data['Version'], wp_scripts()->registered['wp-search-suggest']->ver );
+		$this->assertSame( $plugin_data['Version'], wp_styles()->registered['wp-search-suggest']->ver );
+	}
+
+	/**
+	 * `wpss_init` swaps the `.dev` asset suffix in iff SCRIPT_DEBUG is enabled.
+	 *
+	 * Reads the current SCRIPT_DEBUG state rather than toggling it (the constant
+	 * cannot be redefined mid-process); this asserts that registration honours
+	 * whichever state the runtime is in.
+	 */
+	public function test_init_selects_dev_asset_suffix_based_on_script_debug() {
+		wpss_init();
+
+		$expected_js  = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? 'wpss-search-suggest.dev.js' : 'wpss-search-suggest.js';
+		$expected_css = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? 'wpss-search-suggest.dev.css' : 'wpss-search-suggest.css';
+
+		$this->assertStringEndsWith( $expected_js, wp_scripts()->registered['wp-search-suggest']->src );
+		$this->assertStringEndsWith( $expected_css, wp_styles()->registered['wp-search-suggest']->src );
+	}
+
+	/**
 	 * `wpss_enqueue_scripts` enqueues both the JS and CSS handles registered
 	 * by `wpss_init`.
 	 */


### PR DESCRIPTION
## Summary

Applies the findings from `/unit-tests:audit-tests`:

**`tests/test-ajax-requests.php`**
- Drop the redundant `set_up_before_class` hook re-registration — the plugin already binds those callbacks at load time, so the duplicates only obscured a regression where the plugin stops registering its own hooks.
- Dedupe the near-identical logged-in / logged-out suggest tests via a private helper.
- Rename to behavior-style names (`test_suggest_returns_matching_post_title_for_logged_out_user`, `test_post_url_rejects_invalid_nonce`, etc.).
- Add a logged-out twin to the invalid-nonce test (the `nopriv` branch was previously asserted only via the logged-in case).
- Add full coverage for the previously-untested `wpss-post-url` AJAX endpoint:
  - matching title returns the permalink
  - no-match returns an empty response
  - invalid nonce on the **second** nonce action (`wpss-post-url`) is rejected — collapsing the two nonces into one would no longer slip through.

**`tests/test-wp-search-suggest.php`** (additions on top of the existing file)
- `test_init_localises_two_distinct_nonces` — assert `wpss_options.nonce` and the `_wpnonce` embedded in `wpss_options.ajaxurl` are different values that each verify against their own action (`wpss-post-url` and `wp-search-suggest` respectively). Pins the AGENTS.md "don't conflate them" rule.
- `test_init_uses_plugin_header_version_for_assets` — script + style `ver` matches the `Version:` header. Pins the cache-busting contract.
- `test_init_selects_dev_asset_suffix_based_on_script_debug` — asserts the `.dev.js` / `.dev.css` suffix tracks the current `SCRIPT_DEBUG` state.

**`AGENTS.md`**
- Refresh the **Tests** bullet list to describe the actual coverage, including the new `wpss-post-url`, two-nonce, and SCRIPT_DEBUG tests.

The audit also flagged a suspected cache-key collision in `wpss_get_post_id_from_title` (`'wpss_post_title' . \$title`). On review the prefix is a literal string, not a variable — there is no way two different titles can produce the same key — so no production change is included for that.

## Test plan

- [ ] `npm run test-php` (single-site) passes locally — Docker-bound, run by maintainer.
- [ ] `npm run test-php-multisite` passes locally.
- [ ] CI (`phpunit.yml`) green on PHP 7.4 + 8.4 × single-site + multisite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
