### PR TITLE
Enable Dependabot for composer, npm, and github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,37 @@
+version: 2
+updates:
+    # Enable version updates for Composer
+    - package-ecosystem: 'composer'
+      directory: '/'
+      schedule:
+          interval: 'weekly'
+      open-pull-requests-limit: 5
+      reviewers:
+          - 'obenland'
+      labels:
+          - 'dependencies'
+          - 'composer'
+
+    # Enable version updates for npm
+    - package-ecosystem: 'npm'
+      directory: '/'
+      schedule:
+          interval: 'weekly'
+      open-pull-requests-limit: 5
+      reviewers:
+          - 'obenland'
+      labels:
+          - 'dependencies'
+          - 'npm'
+
+    # Enable version updates for GitHub Actions
+    - package-ecosystem: 'github-actions'
+      directory: '/'
+      schedule:
+          interval: 'weekly'
+      open-pull-requests-limit: 5
+      reviewers:
+          - 'obenland'
+      labels:
+          - 'dependencies'
+          - 'github-actions'


### PR DESCRIPTION
Adds the standard cohort `.github/dependabot.yml` so Dependabot opens weekly PRs for outdated Composer + npm + GitHub Actions deps. This repo currently has open Dependabot security alerts that aren't being surfaced as PRs because no config exists.

Matches the shape already in uploads-unleashed and wp-author-slug — same ecosystems, same weekly cadence, same 5-PR open limit, same reviewer (`@obenland`).