### PR TITLE
Skip validate in tested-up-to workflow when readme already current

### DIFF
--- a/.github/workflows/update-tested-up-to.yml
+++ b/.github/workflows/update-tested-up-to.yml
@@ -2,7 +2,7 @@ name: Update Tested up to
 
 on:
     schedule:
-        - cron: '0 9 * * 1'
+        - cron: '0 9 * * *'
     workflow_dispatch:
 
 permissions:
@@ -14,9 +14,65 @@ concurrency:
     cancel-in-progress: false
 
 jobs:
+    check:
+        name: Check for new WordPress version
+        # Pin scheduled runs to trunk, but allow manual dispatch from any branch
+        # for testing.
+        if: github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/trunk'
+        runs-on: ubuntu-latest
+        timeout-minutes: 5
+        permissions:
+            contents: read
+        outputs:
+            needs_update: ${{ steps.check.outputs.needs_update }}
+            version: ${{ steps.check.outputs.version }}
+            full: ${{ steps.check.outputs.full }}
+            previous: ${{ steps.check.outputs.previous }}
+        steps:
+            - uses: actions/checkout@v6
+              with:
+                  sparse-checkout: readme.txt
+                  sparse-checkout-cone-mode: false
+
+            - name: Compare latest WordPress against readme
+              id: check
+              shell: bash
+              run: |
+                  set -euo pipefail
+                  latest=$(curl -fsSL --connect-timeout 30 --max-time 60 --retry 3 --retry-delay 2 https://api.wordpress.org/core/version-check/1.7/ | jq -r '.offers[0].version')
+                  if ! [[ "$latest" =~ ^[0-9]+\.[0-9]+(\.[0-9]+)?$ ]]; then
+                      echo "Unexpected WordPress version: '$latest'" >&2
+                      exit 1
+                  fi
+                  short=$(echo "$latest" | awk -F. '{print $1"."$2}')
+                  if ! [[ "$short" =~ ^[0-9]+\.[0-9]+$ ]]; then
+                      echo "Failed to derive major.minor from '$latest'" >&2
+                      exit 1
+                  fi
+                  current=$(sed -nE '/^[Tt]ested up to:/{s/^[Tt]ested up to:[[:space:]]+//;s/\r$//;p;q;}' readme.txt)
+                  if [ -z "$current" ]; then
+                      echo "Could not find 'Tested up to:' header in readme.txt" >&2
+                      exit 1
+                  fi
+                  sorted=$(printf '%s\n%s\n' "$current" "$short" | sort -V)
+                  older="${sorted%%$'\n'*}"
+                  if [ "$current" = "$short" ] || [ "$older" != "$current" ]; then
+                      echo "Current ($current) is at or ahead of target ($short); nothing to do."
+                      echo "needs_update=false" >> "$GITHUB_OUTPUT"
+                      exit 0
+                  fi
+                  {
+                      echo "needs_update=true"
+                      echo "version=$short"
+                      echo "full=$latest"
+                      echo "previous=$current"
+                  } >> "$GITHUB_OUTPUT"
+                  echo "Bump needed: $current -> $short (WP $latest)"
+
     validate:
         name: Validate against latest WordPress
-        if: github.ref == 'refs/heads/trunk'
+        needs: check
+        if: needs.check.outputs.needs_update == 'true'
         permissions:
             contents: read
         runs-on: ubuntu-latest
@@ -55,77 +111,138 @@ jobs:
             - name: Run PHP unit tests (multisite) against latest WordPress
               run: npm run test-php-multisite
 
+    notify-failure:
+        name: Open issue when validation fails
+        needs: [check, validate]
+        # Only the canonical trunk run can open tracking issues, so manual
+        # workflow_dispatch from a feature branch can't pollute the issue
+        # tracker with branch-specific failures.
+        if: always() && needs.validate.result == 'failure' && github.ref == 'refs/heads/trunk'
+        runs-on: ubuntu-latest
+        permissions:
+            issues: write
+        steps:
+            - name: Open (or reuse) tracking issue for this WordPress version
+              shell: bash
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  GH_REPO: ${{ github.repository }}
+                  VERSION: ${{ needs.check.outputs.version }}
+                  FULL: ${{ needs.check.outputs.full }}
+                  RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+              run: |
+                  set -euo pipefail
+                  # Idempotently ensure the label exists — --force updates the
+                  # description/color if it does, creates it if it doesn't.
+                  gh label create tested-up-to-failure \
+                      --color B60205 \
+                      --description "Auto-opened by Update Tested up to workflow on validation failure" \
+                      --force >/dev/null
+
+                  # Dedupe by the label we own + the per-version title. The label
+                  # restricts the search to issues we created ourselves, so the
+                  # title check is reliable even though GitHub's search tokenizes
+                  # version strings. --paginate so dedupe still works in a repo
+                  # that has accumulated >100 open failure issues.
+                  title="Validate failed against WordPress $VERSION"
+                  existing=$(gh api -X GET search/issues \
+                      -f q="repo:$GH_REPO is:issue is:open label:tested-up-to-failure" \
+                      -f per_page=100 --paginate \
+                      --jq ".items[] | select(.title == \"$title\") | .number" \
+                      | head -1)
+                  if [ -n "$existing" ]; then
+                      echo "Issue #$existing already tracks this failure; skipping."
+                      exit 0
+                  fi
+                  gh issue create \
+                      --label tested-up-to-failure \
+                      --title "$title" \
+                      --body "$(cat <<EOF
+                  Validation against WordPress \`$FULL\` failed during the \`Update Tested up to\` workflow.
+
+                  Run: $RUN_URL
+
+                  Daily runs will keep retrying. While this issue is open it suppresses duplicate failure reports for WordPress $VERSION; it will auto-close once validation passes against a later patch release.
+                  EOF
+                  )"
+
+    close-failure-issue:
+        name: Close validation-failure issue on success
+        needs: [check, validate]
+        # Match notify-failure's gate so a branch-dispatch can't auto-close a
+        # real tracking issue based on branch-only changes.
+        if: needs.validate.result == 'success' && github.ref == 'refs/heads/trunk'
+        runs-on: ubuntu-latest
+        permissions:
+            issues: write
+        steps:
+            - name: Close any open failure issue for this version
+              shell: bash
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  GH_REPO: ${{ github.repository }}
+                  VERSION: ${{ needs.check.outputs.version }}
+                  FULL: ${{ needs.check.outputs.full }}
+              # Only auto-closes the issue for this exact version. If 6.5 failed
+              # and we now validate green against 6.6, the 6.5 issue stays open
+              # for human review — that failure was real and worth investigating
+              # even after a later release unsticks the workflow.
+              run: |
+                  set -euo pipefail
+                  # search/issues is permissive when the label doesn't exist —
+                  # gh issue list --label would fail in a repo that's never seen
+                  # a failure (and so never had the label created). --paginate
+                  # so the lookup still works in a repo with >100 open failures.
+                  title="Validate failed against WordPress $VERSION"
+                  existing=$(gh api -X GET search/issues \
+                      -f q="repo:$GH_REPO is:issue is:open label:tested-up-to-failure" \
+                      -f per_page=100 --paginate \
+                      --jq ".items[] | select(.title == \"$title\") | .number" \
+                      | head -1)
+                  if [ -z "$existing" ]; then
+                      echo "No matching open issue to close."
+                      exit 0
+                  fi
+                  gh issue close "$existing" \
+                      --comment "Validation passed against WordPress \`$FULL\`. Closing automatically."
+
     update:
-        needs: validate
-        if: github.ref == 'refs/heads/trunk'
+        needs: [check, validate]
+        # Pin to trunk so a workflow_dispatch from a feature branch can't
+        # auto-merge that branch's changes into trunk (peter-evans/create-pull-request
+        # would otherwise produce a PR from the dispatched branch's tree).
+        if: needs.check.outputs.needs_update == 'true' && github.ref == 'refs/heads/trunk'
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v6
 
-            - name: Get latest WordPress version
-              id: wp
-              shell: bash
-              run: |
-                  set -euo pipefail
-                  latest=$(curl -fsSL --connect-timeout 30 --max-time 60 --retry 3 --retry-delay 2 https://api.wordpress.org/core/version-check/1.7/ | jq -r '.offers[0].version')
-                  if ! [[ "$latest" =~ ^[0-9]+\.[0-9]+(\.[0-9]+)?$ ]]; then
-                      echo "Unexpected WordPress version: '$latest'" >&2
-                      exit 1
-                  fi
-                  short=$(echo "$latest" | awk -F. '{print $1"."$2}')
-                  if ! [[ "$short" =~ ^[0-9]+\.[0-9]+$ ]]; then
-                      echo "Failed to derive major.minor from '$latest'" >&2
-                      exit 1
-                  fi
-                  {
-                      echo "version=$short"
-                      echo "full=$latest"
-                  } >> "$GITHUB_OUTPUT"
-                  echo "Latest WordPress: $latest (major.minor: $short)"
-
             - name: Update readme.txt
-              id: update
               shell: bash
+              env:
+                  TARGET: ${{ needs.check.outputs.version }}
+                  PREVIOUS: ${{ needs.check.outputs.previous }}
               run: |
                   set -euo pipefail
-                  target='${{ steps.wp.outputs.version }}'
-                  current=$(sed -nE '/^[Tt]ested up to:/{s/^[Tt]ested up to:[[:space:]]+//;s/\r$//;p;q;}' readme.txt)
-                  if [ -z "$current" ]; then
-                      echo "Could not find 'Tested up to:' header in readme.txt" >&2
-                      exit 1
-                  fi
-                  sorted=$(printf '%s\n%s\n' "$current" "$target" | sort -V)
-                  older="${sorted%%$'\n'*}"
-                  if [ "$current" = "$target" ] || [ "$older" != "$current" ]; then
-                      echo "Current ($current) is at or ahead of target ($target); nothing to do."
-                      echo "updated=false" >> "$GITHUB_OUTPUT"
-                      exit 0
-                  fi
-                  sed -i -E "s/^([Tt]ested up to:[[:space:]]+).*/\1$target/" readme.txt
+                  sed -i -E "s/^([Tt]ested up to:[[:space:]]+).*/\1$TARGET/" readme.txt
                   new=$(sed -nE '/^[Tt]ested up to:/{s/^[Tt]ested up to:[[:space:]]+//;s/\r$//;p;q;}' readme.txt)
-                  if [ "$new" != "$target" ]; then
+                  if [ "$new" != "$TARGET" ]; then
                       echo "sed did not produce expected value (got '$new')" >&2
                       exit 1
                   fi
-                  {
-                      echo "updated=true"
-                      echo "previous=$current"
-                  } >> "$GITHUB_OUTPUT"
-                  echo "Bumped Tested up to: $current -> $target"
+                  echo "Bumped Tested up to: $PREVIOUS -> $TARGET"
 
             - name: Create Pull Request
-              if: steps.update.outputs.updated == 'true'
               id: pr
               uses: peter-evans/create-pull-request@v8
               with:
                   base: trunk
-                  commit-message: 'Bump Tested up to ${{ steps.wp.outputs.version }}'
-                  title: 'Bump Tested up to ${{ steps.wp.outputs.version }}'
+                  commit-message: 'Bump Tested up to ${{ needs.check.outputs.version }}'
+                  title: 'Bump Tested up to ${{ needs.check.outputs.version }}'
                   body: |
-                      WordPress ${{ steps.wp.outputs.full }} is the latest stable release.
+                      WordPress ${{ needs.check.outputs.full }} is the latest stable release.
 
-                      Bumps `Tested up to` in readme.txt from ${{ steps.update.outputs.previous }} to ${{ steps.wp.outputs.version }} (major.minor of ${{ steps.wp.outputs.full }}).
-                  branch: chore/tested-up-to-${{ steps.wp.outputs.version }}
+                      Bumps `Tested up to` in readme.txt from ${{ needs.check.outputs.previous }} to ${{ needs.check.outputs.version }} (major.minor of ${{ needs.check.outputs.full }}).
+                  branch: chore/tested-up-to-${{ needs.check.outputs.version }}
                   delete-branch: true
 
             - name: Merge PR


### PR DESCRIPTION
## Summary

Ports the perf improvements from obenland/wp-author-slug#36 to this repo.

- New `check` job runs first: curls `api.wordpress.org`, reads `readme.txt` via sparse checkout, and exits in ~15-25s when there's nothing to do.
- `validate` and `update` now `needs: check` with `if: needs.check.outputs.needs_update == 'true'`, so the heavy PHPUnit run only fires when there's an actual bump to make.
- Cron switched from weekly (`0 9 * * 1`) to daily (`0 9 * * *`) — no-op runs are cheap enough that daily is fine.
- `update` job drops the redundant WordPress-version fetch and the early-exit branch of `Update readme.txt`; it consumes `needs.check.outputs.{version,full,previous}` directly.
- New `notify-failure` job opens a tracking issue (deduped by title per WP major.minor) when `validate` fails, so daily retries against a known-broken release don't disappear silently.
- New `close-failure-issue` job auto-closes the issue once a later WP patch makes `validate` pass.

Unlike wp-author-slug, this repo keeps the existing `GITHUB_TOKEN` flow and the inline `Sync readme to WordPress.org SVN` step in `update` — no `WORKFLOW_PAT` was needed because there's no required PR CI to retrigger and the inline SVN sync already publishes after merge.

Per-repo `validate` steps (PHPUnit, Playwright, multisite, etc.) are preserved verbatim.

## Test plan

- [ ] Trigger `Update Tested up to` via `workflow_dispatch` while `readme.txt` is at the current WP major.minor → only the `check` job runs, completes in ~15-25s, logs "Current ... is at or ahead of target ...; nothing to do."
- [ ] Temporarily bump `readme.txt` back one minor on a throwaway branch and dispatch → `check` outputs `needs_update=true`, `validate` runs, `update` opens + auto-merges the PR, SVN sync fires.
- [ ] Confirm the next scheduled daily run on a stale day (no new WP) finishes cleanly without firing `validate`.
