### PR TITLE
Run tested-up-to weekly instead of daily

### DIFF
--- a/.github/workflows/update-tested-up-to.yml
+++ b/.github/workflows/update-tested-up-to.yml
@@ -2,7 +2,7 @@ name: Update Tested up to
 
 on:
     schedule:
-        - cron: '0 9 * * *'
+        - cron: '0 9 * * 1'
     workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

Reverts the cron from `0 9 * * *` back to `0 9 * * 1` (weekly, Mondays at 09:00 UTC).

WordPress ships ~3 major.minor releases per year. The `check` job reduces the latest version to `major.minor` before comparing, so patch releases are no-ops too — leaving roughly 3 actual work events per year against 365 daily runs.

Daily made sense as a sanity check when the cheap `check` job first landed (the perf rework made no-op runs free, so daily became affordable). But affordability isn't the same as warranted: weekly catches every release within ~7 days, which is plenty for the `Tested up to:` signal, and cuts the noise on the Actions tab.

## Test plan

- [ ] Confirm the next scheduled run fires on the upcoming Monday at 09:00 UTC instead of every morning.
- [ ] `workflow_dispatch` still works for manual triggers on demand.
