### PR TITLE
Convert readme.txt to README.md

### DIFF
--- a/.github/workflows/update-tested-up-to.yml
+++ b/.github/workflows/update-tested-up-to.yml
@@ -31,7 +31,7 @@ jobs:
         steps:
             - uses: actions/checkout@v6
               with:
-                  sparse-checkout: readme.txt
+                  sparse-checkout: README.md
                   sparse-checkout-cone-mode: false
 
             - name: Compare latest WordPress against readme
@@ -49,9 +49,9 @@ jobs:
                       echo "Failed to derive major.minor from '$latest'" >&2
                       exit 1
                   fi
-                  current=$(sed -nE '/^[Tt]ested up to:/{s/^[Tt]ested up to:[[:space:]]+//;s/\r$//;p;q;}' readme.txt)
+                  current=$(sed -nE '/^[Tt]ested up to:/{s/^[Tt]ested up to:[[:space:]]+//;s/\r$//;p;q;}' README.md)
                   if [ -z "$current" ]; then
-                      echo "Could not find 'Tested up to:' header in readme.txt" >&2
+                      echo "Could not find 'Tested up to:' header in README.md" >&2
                       exit 1
                   fi
                   sorted=$(printf '%s\n%s\n' "$current" "$short" | sort -V)
@@ -216,15 +216,15 @@ jobs:
         steps:
             - uses: actions/checkout@v6
 
-            - name: Update readme.txt
+            - name: Update README.md
               shell: bash
               env:
                   TARGET: ${{ needs.check.outputs.version }}
                   PREVIOUS: ${{ needs.check.outputs.previous }}
               run: |
                   set -euo pipefail
-                  sed -i -E "s/^([Tt]ested up to:[[:space:]]+).*/\1$TARGET/" readme.txt
-                  new=$(sed -nE '/^[Tt]ested up to:/{s/^[Tt]ested up to:[[:space:]]+//;s/\r$//;p;q;}' readme.txt)
+                  sed -i -E "s/^([Tt]ested up to:[[:space:]]+).*/\1$TARGET/" README.md
+                  new=$(sed -nE '/^[Tt]ested up to:/{s/^[Tt]ested up to:[[:space:]]+//;s/\r$//;p;q;}' README.md)
                   if [ "$new" != "$TARGET" ]; then
                       echo "sed did not produce expected value (got '$new')" >&2
                       exit 1
@@ -241,7 +241,7 @@ jobs:
                   body: |
                       WordPress ${{ needs.check.outputs.full }} is the latest stable release.
 
-                      Bumps `Tested up to` in readme.txt from ${{ needs.check.outputs.previous }} to ${{ needs.check.outputs.version }} (major.minor of ${{ needs.check.outputs.full }}).
+                      Bumps `Tested up to` in README.md from ${{ needs.check.outputs.previous }} to ${{ needs.check.outputs.version }} (major.minor of ${{ needs.check.outputs.full }}).
                   branch: chore/tested-up-to-${{ needs.check.outputs.version }}
                   delete-branch: true
 
@@ -294,7 +294,7 @@ jobs:
                   set -euo pipefail
                   # peter-evans/create-pull-request leaves the working tree at the pre-PR
                   # state, and the merge happens on the remote. Pull the post-merge trunk
-                  # so the SVN sync below copies the actually-bumped readme.txt rather than
+                  # so the SVN sync below copies the actually-bumped README.md rather than
                   # the workspace's stale copy.
                   git fetch origin trunk
                   git reset --hard origin/trunk

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Make sure your theme's search input field has an `id="s"` and/or `name="s"` as i
 * Tested for WordPress 3.3.1
 
 ### 1.2
-* Added compatibilty for WordPress 3.3
+* Added compatibility for WordPress 3.3
 * Updated FAQ section
 
 ### 1.1

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-=== WP Search Suggest ===
+# WP Search Suggest
 Contributors: obenland
 Tags: search, AJAX, jQuery
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=TLX9TH5XRURBA
@@ -8,14 +8,14 @@ Stable tag: 8
 
 Provides title suggestions while typing a search query, using the built-in jQuery suggest script.
 
-== Description ==
+## Description
 
 This plugin lets you provide the user with search suggestions based on the information entered in the search field.
 
 It adds an AJAX call to the search form, returning matches for the current search query from the database.
 There is no change of template files necessary as this plugin hooks in the existing WordPress API to unfold its magic.
 
-= Translations =
+### Translations
 I will be more than happy to update the plugin with new locales, as soon as I receive them!
 Currently available in:
 
@@ -24,25 +24,25 @@ Currently available in:
 * Czech
 
 
-== Installation ==
+## Installation
 
 1. Download WP Search Suggest.
 2. Unzip the folder into the `/wp-content/plugins/` directory
 3. Activate the plugin through the 'Plugins' menu in WordPress
 
 
-== Frequently Asked Questions ==
+## Frequently Asked Questions
 
-= The plugin doesn't work with my theme. What's wrong? =
+### The plugin doesn't work with my theme. What's wrong?
 Make sure your theme's search input field has an `id="s"` and/or `name="s"` as in TwentyTen and TwentyEleven. It'll work fine then.
 
 
-== Screenshots ==
+## Screenshots
 
 1. The suggested post and page titles.
 
 
-== Filter Reference ==
+## Filter Reference
 
 **wpss_search_query_args** (*array|string*)
 > The query args, passed to [WP_Query](http://codex.wordpress.org/Function_Reference/WP_Query "WP_Query in the WordPress Codex"), either as an array or a string.
@@ -52,62 +52,62 @@ Make sure your theme's search input field has an `id="s"` and/or `name="s"` as i
 > An array with the result strings as values. An array with the default results and the WP_Query object are passed to the filter.
 
 
-== Changelog ==
+## Changelog
 
-= 8 =
+### 8
 * Fixed a bug where search requests from logged-out users would not return results. See https://wordpress.org/support/topic/only-works-when-logged-in-18/
 
-= 7 =
+### 7
 * Fixed a bug where the plugin would not work with PHP 8.0 and above. See https://wordpress.org/support/topic/after-php-8-not-working-again/
 
-= 6 =
+### 6
 * Bumped z-index of search result box to be compatible with Boldwp theme.
 
-= 5 =
+### 5
 * Fixed a bug where suggested selections could end up redirecting to the wrong version of a post.
 
-= 4 =
+### 4
 * Finally adds support for HTML5 search forms.
 
-= 3 =
+### 3
 * Maintenance release.
 * Updated code to adhere to WordPress Coding Standards.
 * Tested for WordPress 5.0
 
-= 2.1.0 =
+### 2.1.0
 * Maintenance release.
 * Tested for WordPress 4.0
 
-= 2.0.1 =
+### 2.0.1
 * Fixed a bug with how scripts and styles were enqueued.
 
-= 2.0.0 =
+### 2.0.0
 * Now goes directly to the post selected.
 * Changed license to GPLv2 or later
 * Added Czech translation. Props Roman Opet.
 * Minor formatting updates.
 * Removed compatibility for pre-3.3. installations.
 
-= 1.3.1 =
+### 1.3.1
 * Updated utility class
 * Various minor code changes
 
-= 1.3 =
+### 1.3
 * Cut down on filter calls
 * Optimized AJAX handling with jQuery 1.7.1
 * Tested for WordPress 3.3.1
 
-= 1.2 =
+### 1.2
 * Added compatibilty for WordPress 3.3
 * Updated FAQ section
 
-= 1.1 =
+### 1.1
 * Added filters so users can adjust the search query and displayed results to their needs (see Filter Reference)
 * Fixed a bug where titles of unpublished posts were displayed
 
-= 1.0 =
+### 1.0
 * Initial Release
 
 
-== Upgrade Notice ==
+## Upgrade Notice
 Maintenance update for jQuery 1.7.1


### PR DESCRIPTION
## Summary

Renames `readme.txt` to `README.md` (GitHub renders it on the repo home) without giving up the wp.org plugin page.

WordPress.org's plugin-directory parser accepts either filename — its lookup regex is `!(?:^|/)readme\.(txt|md)$!i` (case-insensitive, .md included) — and the section grammar already supports `##` headers alongside `==`. The WP field block (`Contributors:`, `Tested up to:`, `Stable tag:`, …) stays in the same `Field: Value` format in both files. Within sections, `### x.y.z` becomes the changelog entry form (since `###` doesn't end a section).

Workflows that read or write the readme are updated to point at `README.md`:

- `update-tested-up-to.yml` — sparse-checkout, the `[Tt]ested up to:` sed/grep, and the PR body
- `push-asset-readme-update.yml` / `plugin-asset-update.yml` — path triggers
- `phpunit*.yml`, `playwright*.yml`, `test-e2e.yml` — `paths-ignore` arrays

For uploads-unleashed, `release.yml`'s changelog-insertion logic is also rewritten: it now greps for `^### <tag>$` and inserts after `^## Changelog`, and `.distignore` no longer excludes `README.md` from the SVN sync.

## Test plan

- [ ] GitHub renders README.md on the repo home.
- [ ] Next scheduled `update-tested-up-to` run finds the `Tested up to:` header in README.md and behaves the same as before.
- [ ] wp.org plugin page continues to show the readme content on the next deploy (parser picks up README.md via the case-insensitive lookup).
